### PR TITLE
Add "View on site" links to admin

### DIFF
--- a/metadeploy/api/models.py
+++ b/metadeploy/api/models.py
@@ -344,6 +344,10 @@ class Product(HashIdMixin, SlugMixin, AllowedListAccessMixin, TranslatableModel)
     def get_translation_strategy(self):
         return "fields", f"{self.slug}:product"
 
+    def get_absolute_url(self):
+        # See src/js/utils/routes.ts
+        return f"/products/{self.slug}"
+
 
 class VersionQuerySet(TranslatableQuerySet):
     def get_by_natural_key(self, *, product, label):
@@ -402,6 +406,10 @@ class Version(HashIdMixin, TranslatableModel):
 
     def get_translation_strategy(self):
         return "fields", f"{self.product.slug}:version:{self.label}"
+
+    def get_absolute_url(self):
+        # See src/js/utils/routes.ts
+        return f"/products/{self.product.slug}/{self.label}"
 
 
 class PlanSlug(AbstractSlug):
@@ -558,6 +566,10 @@ class Plan(HashIdMixin, SlugMixin, AllowedListAccessMixin, TranslatableModel):
             "fields",
             f"{self.plan_template.product.slug}:plan:{self.plan_template.name}",
         )
+
+    def get_absolute_url(self):
+        # See src/js/utils/routes.ts
+        return f"/products/{self.version.product.slug}/{self.version.label}/{self.slug}"
 
     def is_visible_to(self, *args, **kwargs):
         if self.supported_orgs != SUPPORTED_ORG_TYPES.Persistent:
@@ -728,6 +740,13 @@ class Job(HashIdMixin, models.Model):
     def instance_url(self):
         if self.user:
             return self.user.instance_url
+
+    def get_absolute_url(self):
+        # See src/js/utils/routes.ts
+        return (
+            f"/products/{self.plan.version.product.slug}/{self.plan.version.label}/"
+            f"{self.plan.slug}/jobs/{self.id}"
+        )
 
     def subscribable_by(self, user, session):
         # Restrict this to public Jobs, staff users, Job owners, or users who have a

--- a/metadeploy/api/tests/models.py
+++ b/metadeploy/api/tests/models.py
@@ -243,6 +243,9 @@ class TestIconProperty:
 
 @pytest.mark.django_db
 class TestVersion:
+    def test_get_absolute_url(self, version_factory):
+        assert version_factory().get_absolute_url().startswith("/")
+
     def test_primary_plan__none(self, version_factory):
         version = version_factory()
         assert version.primary_plan is None
@@ -287,9 +290,13 @@ def test_product_category_str(product_category_factory):
 
 
 @pytest.mark.django_db
-def test_product_str(product_factory):
-    product = product_factory(title="My Product")
-    assert str(product) == "My Product"
+class TestProduct:
+    def test_str(self, product_factory):
+        product = product_factory(title="My Product")
+        assert str(product) == "My Product"
+
+    def test_get_absolute_url(self, product_factory):
+        assert product_factory().get_absolute_url().startswith("/")
 
 
 @pytest.mark.django_db
@@ -410,6 +417,9 @@ class TestPlan:
         version = version_factory(label="v0.1.0", product=product)
         plan = plan_factory(title="My Plan", version=version)
         assert str(plan) == "My Product, Version v0.1.0, Plan My Plan"
+
+    def test_get_absolute_url(self, plan_factory):
+        assert plan_factory().get_absolute_url().startswith("/")
 
     def test_is_visible_to(self, allowed_list_factory, plan_factory, user_factory):
         allowed_list = allowed_list_factory(org_type=["Production"])
@@ -558,6 +568,9 @@ class TestVersionNaturalKey:
 
 @pytest.mark.django_db
 class TestJob:
+    def test_get_absolute_url(self, job_factory):
+        assert job_factory().get_absolute_url().startswith("/")
+
     def test_job_saves_click_through_text(self, plan_factory, job_factory):
         plan = plan_factory(version__product__click_through_agreement="Test")
         job = job_factory(plan=plan, org_id="00Dxxxxxxxxxxxxxxx")


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&210716)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


<!--
## Description
Uncomment if you want to provide a custom description.
-->


## Steps to test/reproduce
Visit the admin detail page for Products, Versions, Plans, or Jobs. In the top-right corner you'll see a "View on site" link that will take you to the frontend URL for the object.

## Show me
![image](https://user-images.githubusercontent.com/2391102/125992790-27e8339b-5a81-49c1-a2d7-bf95a40ef64a.png)
