### PR TITLE
[remove-scroll] Use % instead of vw for main container

### DIFF
--- a/src/js/index.tsx
+++ b/src/js/index.tsx
@@ -42,7 +42,7 @@ const history = createBrowserHistory();
 
 const App = () => (
   <DocumentTitle title={window.SITE_NAME}>
-    <div className="slds-grid slds-grid_frame slds-grid_vertical">
+    <div className="slds-grid slds-grid_frame slds-grid_vertical metadeploy-frame">
       <ErrorBoundary>
         <div className="slds-grow slds-shrink-none">
           <ErrorBoundary>

--- a/src/sass/patterns/_containers.scss
+++ b/src/sass/patterns/_containers.scss
@@ -1,6 +1,11 @@
 // Containers
 // ==========
 
+// Prevent unwanted horizontal scroll by overriding the 100vw applied by slds-grid_frame
+.metadeploy-frame {
+  min-width: 100%;
+}
+
 // Restrict fixed/absolute containers to half the viewport
 // ie. used on toast containers to unblock header links
 .half-container {


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&dag)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->



## Description
Remove horizontal scroll on pages that scroll vertically.



## Steps to test/reproduce

Shorten the browser height on any page or visit the Community Products tab on the products page. 

_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._


## Show me
Before:

![image](https://user-images.githubusercontent.com/41588129/172648959-0b9215c9-3aad-4fb6-bfe8-b28bcfd63f1f.png)

After:

![image](https://user-images.githubusercontent.com/41588129/172649162-5a201b1b-6c86-4b1b-8952-bd22b567f41b.png)



_Provide screenshots/animated gifs/videos if necessary._


# REMEMBER: Attach this PR to the Trello card
